### PR TITLE
Make getResource public.

### DIFF
--- a/src/Resources/GetResource.php
+++ b/src/Resources/GetResource.php
@@ -13,7 +13,7 @@ trait GetResource {
    */
   protected $factory;
 
-  protected function getResource($resource_type, $id) {
+  public function getResource($resource_type, $id) {
     $response = $this->factory->request($resource_type, $id);
     return $this->factory->createObjectType($resource_type, $response->json());
   }


### PR DESCRIPTION
Running 

``` php
<?php

require __DIR__ . '/vendor/autoload.php';

use EclipseGc\DrupalOrg\Api\DrupalClient;

$client = DrupalClient::create();

$user = $client->getUser(1);
```

gives

> Fatal error: Access level to EclipseGc\DrupalOrg\Api\Resources\GetResource::getResource() must be public (as in class EclipseGc\DrupalOrg\Api\Resources\ResourceInterface) in /Users/clemens/Sites/drupal/d.o/json/vendor/eclipsegc/drupal-org-api/src/Resources/User.php on line 242

Making getResource public fetches a user. Not sure this is the right solution.
